### PR TITLE
Fix code scanning alert no. 5: Reflected cross-site scripting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "cors": "^2.8.5",
-    "express": "^4.21.1"
+    "express": "^4.21.1",
+    "escape-html": "^1.0.3"
   }
 }

--- a/steelCookies.js
+++ b/steelCookies.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const app = express();
+const escapeHtml = require('escape-html');
 let texto = "";
 let cokkiesQueGuardo = "";
 //let cookies = document.cookie;
@@ -22,7 +23,7 @@ app.get('/grab', (req, res) => {
   
   app.get('/cookir', (req, res) => {
       let cookie = req.query.cookie
-      cokkiesQueGuardo = cookie
+      cokkiesQueGuardo = escapeHtml(cookie)
       console.log("Cookies que he virlado:" + cookie)
       res.send('Hola wuenas tardes, estas cookies estan almacenadas:' + cokkiesQueGuardo)
   


### PR DESCRIPTION
Fixes [https://github.com/Arkant04/testNodeALe/security/code-scanning/5](https://github.com/Arkant04/testNodeALe/security/code-scanning/5)

To fix the problem, we need to sanitize the user input before incorporating it into the response. The best way to do this is by using a well-known library for escaping HTML, such as `escape-html`. This will ensure that any potentially malicious characters in the user input are properly escaped, preventing XSS attacks.

We will need to:
1. Install the `escape-html` library.
2. Import the `escape-html` library in the `steelCookies.js` file.
3. Use the `escape-html` function to sanitize the `cookie` variable before including it in the response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
